### PR TITLE
Updated LS::LSApp::Initialize() to SharedRef of command args so it ca…

### DIFF
--- a/GameTest/main.cpp
+++ b/GameTest/main.cpp
@@ -40,7 +40,7 @@ import ImGuiWindowTest;
 
 Ref<LS::LSApp> CreateApp(uint32_t choice)
 {
-    switch(choice)
+    switch (choice)
     {
     case 0:
     {
@@ -102,19 +102,13 @@ int main(int argc, char* argv[])
 #else // I know I don't need this, but wondering if maybe I just should consider supporting this?
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
-    //TODO: Come back to later because WinMain is something I still am learning to deal with.
-    /*LPSTR cmdline = GetCommandLineA();
-    auto args = LS::ParseCommands(cmdline);
-
     auto app = CreateApp(1);
-    auto appcode = app->Initialize(args);
+    auto appcode = app->Initialize(nullptr);
     if (!appcode)
     {
-        std::cout << appcode.Message() << "\n";
-        return -1;
+        return WM_QUIT;
     }
-    app->Run();*/
-
+    app->Run();
     return WM_QUIT;
 }
 #endif

--- a/GameTest/src/DX11Test/DX11CubeApp.ixx
+++ b/GameTest/src/DX11Test/DX11CubeApp.ixx
@@ -84,7 +84,7 @@ namespace gt::dx11
         DX11CubeApp(uint32_t width, uint32_t height, std::wstring_view title);
         ~DX11CubeApp() = default;
 
-        auto Initialize([[maybe_unused]] const LS::LSCommandArgs& args) -> System::ErrorCode override;
+        auto Initialize([[maybe_unused]] SharedRef<LS::LSCommandArgs> args) -> System::ErrorCode override;
         void Run() override;
 
     private:
@@ -274,7 +274,7 @@ gt::dx11::DX11CubeApp::DX11CubeApp(uint32_t width, uint32_t height, std::wstring
 {
 }
 
-auto gt::dx11::DX11CubeApp::Initialize(const LS::LSCommandArgs& args) -> LS::System::ErrorCode
+auto gt::dx11::DX11CubeApp::Initialize(SharedRef<LS::LSCommandArgs> args) -> LS::System::ErrorCode
 {
     using enum LS::System::ErrorStatus;
     //auto& window = Window;

--- a/GameTest/src/DX12Test/CubeApp.ixx
+++ b/GameTest/src/DX12Test/CubeApp.ixx
@@ -147,7 +147,7 @@ namespace gt::dx12
         }
         ~DX12CubeApp() = default;
 
-        auto Initialize(const LS::LSCommandArgs& args) -> LS::System::ErrorCode override;
+        auto Initialize(SharedRef<LS::LSCommandArgs> args) -> LS::System::ErrorCode override;
         void Run() override;
 
         //[[nodiscard]] bool LoadPipeline();
@@ -754,7 +754,7 @@ void gt::dx12::DX12CubeApp::Update()
     m_commandList->DrawIndexedInstanced(_countof(g_indices), 1);
 }
 
-auto gt::dx12::DX12CubeApp::Initialize(const LS::LSCommandArgs& args) -> LS::System::ErrorCode
+auto gt::dx12::DX12CubeApp::Initialize(SharedRef<LS::LSCommandArgs> args) -> LS::System::ErrorCode
 {
     if (!CreateDevice())
         return LS::System::CreateFailCode("Failed to create device.");

--- a/GameTest/src/DX12Test/ImGuiWIndowTest.ixx
+++ b/GameTest/src/DX12Test/ImGuiWIndowTest.ixx
@@ -68,7 +68,7 @@ namespace gt::dx12::ImGuiSample
 
         ~ImGuiSample() = default;
 
-        auto Initialize(const LS::LSCommandArgs& args) -> LS::System::ErrorCode override;
+        auto Initialize(SharedRef<LS::LSCommandArgs> args) -> LS::System::ErrorCode override;
         void Run() override;
         void CreateRenderTargets();
         void CleanupRenderTargets();
@@ -107,7 +107,7 @@ module : private;
 
 using namespace gt::dx12;
 
-auto gt::dx12::ImGuiSample::ImGuiSample::Initialize(const LS::LSCommandArgs& args) -> LS::System::ErrorCode
+auto gt::dx12::ImGuiSample::ImGuiSample::Initialize(SharedRef<LS::LSCommandArgs> args) -> LS::System::ErrorCode
 {
     if (!CreateDeviceD3D())
         return LS::System::CreateFailCode("Failed to create device D3D");

--- a/GameTest/src/DX12Test/SimpleWindow.ixx
+++ b/GameTest/src/DX12Test/SimpleWindow.ixx
@@ -66,7 +66,7 @@ namespace gt::dx12
 
         ~SimpleWindow() = default;
 
-        auto Initialize(const LS::LSCommandArgs& args) -> LS::System::ErrorCode override;
+        auto Initialize(SharedRef<LS::LSCommandArgs> args) -> LS::System::ErrorCode override;
         void Run() override;
 
     private:
@@ -97,7 +97,7 @@ namespace gt::dx12
 
 module : private;
 
-auto gt::dx12::SimpleWindow::Initialize(const LS::LSCommandArgs& args) -> LS::System::ErrorCode
+auto gt::dx12::SimpleWindow::Initialize(SharedRef<LS::LSCommandArgs> args) -> LS::System::ErrorCode
 {
     if (!LoadPipeline())
     {

--- a/LunaSolGameEngine/LunaSolGameEngine.vcxproj
+++ b/LunaSolGameEngine/LunaSolGameEngine.vcxproj
@@ -167,7 +167,7 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <TreatWarningAsError>false</TreatWarningAsError>
       <AdditionalIncludeDirectories>$(ProjectDir)inc;$(ProjectDir)modules;</AdditionalIncludeDirectories>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>LSEFramework.h</PrecompiledHeaderFile>

--- a/LunaSolGameEngine/modules/engine/EngineApp.ixx
+++ b/LunaSolGameEngine/modules/engine/EngineApp.ixx
@@ -28,8 +28,8 @@ export namespace LS::Global
 namespace LS
 {
     export using LSCommandArgs = std::vector<std::string>;
-    export auto ParseCommands(int argc, char* argv[]) noexcept -> LSCommandArgs;
-    export auto ParseCommands(std::string_view args) noexcept -> LSCommandArgs;
+    export auto ParseCommands(int argc, char* argv[]) noexcept -> SharedRef<LSCommandArgs>;
+    export auto ParseCommands(std::string_view args) noexcept -> SharedRef<LSCommandArgs>;
 
     /**
      * @brief Creates the device with the supported rendering type
@@ -65,12 +65,11 @@ namespace LS
         LSApp(LSApp&&) = default;
         LSApp& operator=(LSApp&&) = default;
 
-        [[nodiscard]] virtual auto Initialize([[maybe_unused]] const LSCommandArgs& args) -> System::ErrorCode = 0;
+        [[nodiscard]] virtual auto Initialize([[maybe_unused]] SharedRef<LSCommandArgs> args) -> System::ErrorCode = 0;
         virtual void Run() = 0;
 
     protected:
         Ref<LSWindowBase> Window;
-        LSCommandArgs CommandArgs;
         //TODO: Get rid of this ugly mess.
         bool IsRunning = false;
         bool IsPaused = false;
@@ -102,28 +101,28 @@ namespace LS
         Window->RegisterMouseMoveCallback(cursorMove);
     }
 
-    auto ParseCommands(int argc, char* argv[]) noexcept -> LSCommandArgs
+    auto ParseCommands(int argc, char* argv[]) noexcept -> SharedRef<LSCommandArgs>
     {
-        LSCommandArgs commandArgs;
+        SharedRef<LSCommandArgs> commandArgs = std::make_shared<LSCommandArgs>();
         int i = 1;
         for (; i < argc; ++i)
         {
-            commandArgs.emplace_back(argv[i]);
+            commandArgs->emplace_back(argv[i]);
         }
 
         return commandArgs;
     }
 
-    auto ParseCommands([[maybe_unused]] std::string_view args) noexcept -> LSCommandArgs
+    auto ParseCommands([[maybe_unused]] std::string_view args) noexcept -> SharedRef<LSCommandArgs>
     {
-        LSCommandArgs commandArgs;
+        SharedRef<LSCommandArgs> commandArgs = std::make_shared<LSCommandArgs>();
         const auto delim = ' ';
         std::string arg;
         for (auto i = 0; i < args.size(); ++i)
         {
             if (args[i] == delim)
             {
-                commandArgs.push_back(arg);
+                commandArgs->push_back(arg);
             }
             arg += args[i];
         }

--- a/LunaSolGameEngine/modules/engine/EngineLogger.ixx
+++ b/LunaSolGameEngine/modules/engine/EngineLogger.ixx
@@ -153,7 +153,7 @@ void LS::Log::LSLogger::Print(std::wstring_view msg) noexcept
     Print(m_logLevel, msg);
 }
 
-void LS::Log::LSLogger::Print(std::string_view msg) noexcept
+void LS::Log::LSLogger::Print([[maybe_unused]] std::string_view msg) noexcept
 {
 }
 

--- a/LunaSolGameEngine/modules/platform/Windows/FrameBufferDxgi.ixx
+++ b/LunaSolGameEngine/modules/platform/Windows/FrameBufferDxgi.ixx
@@ -124,7 +124,7 @@ export namespace LS::Platform::Dx12
         {
             // TODO: Clear whole screen, maybe later can optimize to clear a part of the screen
             // using this. 
-            const DXGI_PRESENT_PARAMETERS params{ .DirtyRectsCount = 0,
+            static const DXGI_PRESENT_PARAMETERS params{ .DirtyRectsCount = 0,
             .pDirtyRects = NULL, .pScrollRect = NULL, .pScrollOffset = NULL };
 
             auto hr = m_pSwapChain->Present1(m_syncInterval, 0, &params);

--- a/LunaSolGameEngine/src/platform/D3D12/CommandListDx12.cpp
+++ b/LunaSolGameEngine/src/platform/D3D12/CommandListDx12.cpp
@@ -60,13 +60,17 @@ auto CommandListDx12::Initialize(ID3D12Device4* pDevice) noexcept -> LS::System:
 
 void CommandListDx12::ResetCommandList() noexcept
 {
-    LS::Utils::ThrowIfFailed(m_pAllocator->Reset(), std::format("Failed to reset command allocator for: {}", m_name.c_str()));
-    LS::Utils::ThrowIfFailed(m_pCommandList->Reset(m_pAllocator.Get(), nullptr), std::format("Failed to reset command allocator: {}", m_name.c_str()));
+    m_pAllocator->Reset();
+    m_pCommandList->Reset(m_pAllocator.Get(), nullptr);
+
+    //LS::Utils::ThrowIfFailed(m_pAllocator->Reset(), std::format("Failed to reset command allocator for: {}", m_name.c_str()));
+    //LS::Utils::ThrowIfFailed(m_pCommandList->Reset(m_pAllocator.Get(), nullptr), std::format("Failed to reset command allocator: {}", m_name.c_str()));
 }
 
 void CommandListDx12::Close() noexcept
 {
-    LS::Utils::ThrowIfFailed(m_pCommandList->Close(), std::format("Failed to close command list: {}", m_name.c_str()));
+    m_pCommandList->Close();
+    //LS::Utils::ThrowIfFailed(m_pCommandList->Close(), std::format("Failed to close command list: {}", m_name.c_str()));
 }
 
 void CommandListDx12::Clear(const std::array<float, 4>& clearColor, const D3D12_CPU_DESCRIPTOR_HANDLE rtv) noexcept


### PR DESCRIPTION
…n be optional

- Fixed API calls due to taking SharedRef
- ParseCommand functions now return share dref
- FrameBufferDxgi::Prsent() declares a static const DXGI_PRESENT_PARAMETERS since it never changes. (For now)
- Removed some of the ThrowIfFailed(). Considering making the a debug only variant where the throw gets stripped away if in release.