### PR TITLE
Added Additional APIs for Creating Shaders

### DIFF
--- a/LunaSolGameEngine/modules/data/BufferTypes.ixx
+++ b/LunaSolGameEngine/modules/data/BufferTypes.ixx
@@ -40,6 +40,9 @@ export namespace LS
         SHADER_RESOURCE // @brief Buffer is a resource (texture or other type) that is used for shaders (not a constant buffer data)
     };
 
+    /**
+     * @brief Denotes where the buffer is expected to be bound to 
+     */
     enum class BUFFER_BIND_TYPE : uint16_t
     {
         UNKNOWN = 0,
@@ -63,31 +66,35 @@ export namespace LS
         WRITE_AND_READ = 3
     };
 
-    enum class ResourceState : uint8_t
+    enum class RESOURCE_STATE : uint8_t
     {
         UNLOCKED,
         LOCKED
     };
 
     //TODO: Add constraints to this... because I don't know what but I'm sure I"ll think of some later!
+    // 1. Should be the object type (not pointers)
+    // 2. Should be constructible by default without params
+    // 3. Should also allow for empty constructed objects (like an array)
     template<class TObject>
     class LSBuffer
     {
     protected:
         TObject                 m_bufferObject;
         std::string             m_bufferName{ "default" };
-        size_t                  m_stride{ 0 };// @brief
-        size_t                  m_count{ 0 };// @brief The number of elements that this buffer has
+        size_t                  m_stride{ 0 };// @brief the number of bytes for an element of the array
+        size_t                  m_width{ 0 };// @brief the number of bytes in a row (always set - 1D and greater arrays)
+        size_t                  m_rows{ 0 };// @brief the number of rows in the 2D array (0 for 1D arrays))
+        size_t                  m_depth{ 0 };// @brief the number of 2D arays for the 3D array (0 for 1D/2D arrays only)
         BUFFER_USAGE            m_usage{ BUFFER_USAGE::DEFAULT_RW }; // @brief details how the data will be used
         BUFFER_BIND_TYPE        m_bindType{ BUFFER_BIND_TYPE::UNKNOWN }; // @brief Information on what stage in the graphics pipeline this buffer is used
         CPU_RESOURCE_ACCESS     m_cpuAccess{ CPU_RESOURCE_ACCESS::UNDEFINED };
-        ResourceState           m_state;
+        RESOURCE_STATE          m_state{ RESOURCE_STATE::UNLOCKED };
     public:
         LSBuffer(TObject obj, std::string_view name, size_t stride = 0, size_t count = 0) :
             m_bufferObject(obj),
             m_bufferName(name.data()),
-            m_stride(stride),
-            m_count(count)
+            m_stride(stride)
         {
         }
 
@@ -123,9 +130,19 @@ export namespace LS
             return m_stride;
         }
 
-        constexpr auto GetCount() const -> size_t
+        constexpr auto GetWidth() const -> size_t
         {
-            return m_count;
+            return m_width;
+        }
+
+        constexpr auto GetRows() const -> size_t
+        {
+            return m_rows;
+        }
+
+        constexpr auto GetDepth() const -> size_t
+        {
+            return m_depth;
         }
 
         constexpr auto GetUsage() const -> BUFFER_USAGE

--- a/LunaSolGameEngine/modules/data/Shader.ixx
+++ b/LunaSolGameEngine/modules/data/Shader.ixx
@@ -8,12 +8,19 @@ module;
 #include <span>
 #include <format>
 
+#include "engine/EngineDefines.h"
 export module LSEDataLib:Shader;
 
 import Util.StdUtils;
 
 export namespace LS
 {
+    struct ShaderCompileResult
+    {
+        std::vector<std::byte> CompiledCode;
+        std::string ErrMsg;
+    };
+
     enum class SHADER_TYPE
     {
         VERTEX,
@@ -172,12 +179,11 @@ export namespace LS
 
     struct LSShaderFile
     {
-        SHADER_TYPE				m_shaderType;//@brief Shader type
-        std::filesystem::path	m_filePath{};//@brief The file's path
-        std::filesystem::path	m_includePath{ "." };//@brief The directory to look at for include (default to current directory of file)
-        std::string				m_entryPoint{ "main" }; //@brief The main entry point into the shader (if not main)
-        std::string				m_shaderTarget{};//@brief The target profile to compile in
-        std::fstream			m_file;//@brief The file
+        SHADER_TYPE             m_shaderType;//@brief Shader type
+        std::filesystem::path   m_filePath{};//@brief The file's path
+        std::filesystem::path   m_includePath{ "." };//@brief The directory to look at for include (default to current directory of file)
+        std::string             m_entryPoint{ "main" }; //@brief The main entry point into the shader (if not main)
+        std::string             m_shaderTarget{};//@brief The target profile to compile in
     };
 
     /**
@@ -229,16 +235,28 @@ export namespace LS
             };
             Elements.emplace_back(elem);
         }
-        
+
         bool operator==(const LSShaderInputSignature& rhs) const
         {
             return this->Elements == rhs.Elements;
         }
+
         bool operator!=(const LSShaderInputSignature& rhs) const
         {
             return !(*this == rhs);
         }
 
         std::vector<ShaderElement> Elements;
+    };
+
+    struct Shader
+    {
+        // Buffers/Resources
+        // * Slots 
+        // * Type
+        // * Object/View to resource
+
+        // Name 
+        // View to shader / Guid
     };
 }

--- a/LunaSolGameEngine/modules/platform/Windows/D3D11/DeviceD3D11.ixx
+++ b/LunaSolGameEngine/modules/platform/Windows/D3D11/DeviceD3D11.ixx
@@ -5,6 +5,7 @@ module;
 
 #include <wrl/client.h>
 #include <d3d11_4.h>
+#include "engine/EngineDefines.h"
 export module D3D11.Device;
 import LSEDataLib;
 import Engine.LSDevice;

--- a/LunaSolGameEngine/modules/platform/Windows/D3D11/Helpers/D3D11HelperStates.ixx
+++ b/LunaSolGameEngine/modules/platform/Windows/D3D11/Helpers/D3D11HelperStates.ixx
@@ -118,7 +118,7 @@ export namespace LS::Win32
     }
 
     // Depth Stencil States //
-    [[nodiscard]] auto CreateDepthStencilState(ID3D11Device5* pDevice, const DepthStencil& depthStencil) -> Nullable<WRL::ComPtr<ID3D11DepthStencilState>>
+    [[nodiscard]] auto CreateDepthStencilState(ID3D11Device* pDevice, const DepthStencil& depthStencil) -> Nullable<WRL::ComPtr<ID3D11DepthStencilState>>
     {
         assert(pDevice);
         if (!pDevice)
@@ -211,7 +211,7 @@ export namespace LS::Win32
         return pState;
     }
 
-    [[nodiscard]] auto CreateDepthStencilState(ID3D11Device5* pDevice, const D3D11_DEPTH_STENCIL_DESC depthDesc) -> Nullable<WRL::ComPtr<ID3D11DepthStencilState>>
+    [[nodiscard]] auto CreateDepthStencilState(ID3D11Device* pDevice, const D3D11_DEPTH_STENCIL_DESC depthDesc) -> Nullable<WRL::ComPtr<ID3D11DepthStencilState>>
     {
         assert(pDevice);
         if (!pDevice)

--- a/LunaSolGameEngine/modules/platform/Windows/D3D11/RenderD3D11.ixx
+++ b/LunaSolGameEngine/modules/platform/Windows/D3D11/RenderD3D11.ixx
@@ -2,6 +2,7 @@ module;
 #include <cstdint>
 #include <array>
 #include <span>
+#include <filesystem>
 #include <wrl/client.h>
 #include <d3d11_4.h>
 #include "engine/EngineDefines.h"
@@ -40,6 +41,56 @@ namespace WRL = Microsoft::WRL;
 
 export namespace LS::Win32
 {
+    enum class RENDER_MODE
+    {
+        IMMEDIATE,
+        DEFERRED
+    };
+
+    class RenderCommandD3D11
+    {
+    public:
+        RenderCommandD3D11(ID3D11Device* pDevice, RENDER_MODE mode);
+        ~RenderCommandD3D11();
+
+        // Bind Shaders to Pipeline //
+        BindVS();
+        BindPS();
+        BindGS();
+        BindCS();
+        BindHS();
+        BindDS();
+
+        // Bind Commands for Resources for Shaders //
+        SetTexture();
+        SetConstantBuffer();
+        SetVertexBuffer();
+        SetIndexBuffer();
+        SetSampler();
+
+        // Set Input For this Draw State //
+        SetRenderTarget();
+        SetRasterizerState();
+        SetPrimTopology();
+        SetInputLayout;
+        SetViewPort();
+        SetDepthStencilState();
+        SetBlendState();
+
+        // Draw Commands //
+        Clear();
+        ClearDepth();
+        DrawIndexed();
+        DrawVerts();
+
+        // State Operations //
+        Finish(); // @brief Finishes recording command list if DEFERRED, else nothing for IMMEDIATE
+        ClearState(); // @brief Resets to default state
+        FlushCommands();// @brief Expunge all commands recorded up to this point
+    private:
+        WRL::ComPtr<ID3D11DeviceContext4> m_context;
+    };
+
     class RenderD3D11
     {
     public:
@@ -62,6 +113,13 @@ export namespace LS::Win32
         auto GetDeviceCom() noexcept -> WRL::ComPtr<ID3D11Device>;
         auto GetSwapChainCom() noexcept -> WRL::ComPtr<IDXGISwapChain1>;
         auto GetDeviceContextCom() noexcept -> WRL::ComPtr<ID3D11DeviceContext>;
+
+        auto CreateVertexShader(std::span<std::byte> data) noexcept -> WRL::ComPtr<ID3D11VertexShader>;
+        auto CreatePixelShader(std::span<std::byte> data) noexcept -> WRL::ComPtr<ID3D11PixelShader>;
+        auto CreateGeometryShader(std::span<std::byte> data) noexcept -> WRL::ComPtr<ID3D11GeometryShader>;
+        auto CreateDomainShader(std::span<std::byte> data) noexcept -> WRL::ComPtr<ID3D11DomainShader>;
+        auto CreateHullShader(std::span<std::byte> data) noexcept -> WRL::ComPtr<ID3D11HullShader>;
+        auto CreateComputeShader(std::span<std::byte> data) noexcept -> WRL::ComPtr<ID3D11ComputeShader>;
 
         /**
          * @brief Creates an input layout from the given compiled bytecode. This will not work if it was not compiled first.

--- a/LunaSolGameEngine/modules/platform/Windows/DXGI/DXGIHelper.ixx
+++ b/LunaSolGameEngine/modules/platform/Windows/DXGI/DXGIHelper.ixx
@@ -70,7 +70,7 @@ export namespace LS::Win32
     void LogOutputDisplayModes(IDXGIOutput* const output, DXGI_FORMAT format) noexcept;
 
     // Returns a DXGI HRESULT into a LS::System::ErrorCode
-    constexpr auto DxgiErrorToString(HRESULT hr) noexcept -> const char*;
+    constexpr auto HResultToDxgiError(HRESULT hr) noexcept -> const char*;
 }
 
 module : private;
@@ -346,7 +346,7 @@ void LS::Win32::LogOutputDisplayModes(IDXGIOutput* const output, DXGI_FORMAT for
     }
 }
 
-auto DxgiErrorToString(HRESULT hr) noexcept -> const char*
+auto HResultToDxgiError(HRESULT hr) noexcept -> const char*
 {
     using namespace LS::System;
 


### PR DESCRIPTION
- RendererD3D11 will help create shader objects from compiled objects. (Recommend using CompileFromFile() still for shader compilation)
- Updated DX11CubeApp to reflect these changes
- Added Create__Shader calls to D3D11Utils
- Added a new return type ShaderResult for containing the error message or compiled byte code
- Renamed the functions that return error string from HRESULT type to HResultTo___Error instead.
- CreateDepthStencilState takes an ID3D11Device* from ID3D11Device5*
- Added additional members to LSBuffer but still haven't figured out how I want to utilize the object.